### PR TITLE
[DEVHAS-339] Remove resource limits

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -47,9 +47,7 @@ components:
   - name: kubernetes-deploy
     attributes:
       deployment/replicas: 1
-      deployment/cpuLimit: '100m'
       deployment/cpuRequest: 10m
-      deployment/memoryLimit: 300Mi
       deployment/memoryRequest: 100Mi
       deployment/container-port: 8081
     kubernetes:
@@ -61,9 +59,7 @@ components:
   - name: kubernetes-service
     attributes:
       deployment/replicas: 1
-      deployment/cpuLimit: '100m'
       deployment/cpuRequest: 10m
-      deployment/memoryLimit: 200Mi
       deployment/memoryRequest: 100Mi
       deployment/container-port: 8081
     kubernetes:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -20,3 +20,7 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -20,8 +20,3 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
-          resources:
-            limits:
-              memory: "1024Mi"
-              cpu: "500m"
-


### PR DESCRIPTION
# What does this PR do?

Removes the resource limits from the devfile and `deploy.yaml` kubernetes deploy spec to ensure compatibility to the Red Hat Hybrid Application Console when setting the resource requests.

In addition, the resource requests defined in the devfile has now been added to `deploy.yaml` in preparation for deprecating the `attribute` fields shared between the two files.