### PR TITLE
Update port from 8081 to 8080

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -49,19 +49,19 @@ components:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 100Mi
-      deployment/container-port: 8081
+      deployment/container-port: 8080
     kubernetes:
       uri: kubernetes/deployment.yaml
       endpoints:
-        - name: http-8081
-          targetPort: 8081
+        - name: http-8080
+          targetPort: 8080
           path: /
   - name: kubernetes-service
     attributes:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 100Mi
-      deployment/container-port: 8081
+      deployment/container-port: 8080
     kubernetes:
       uri: kubernetes/service.yaml
 commands:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ RUN dotnet publish -c Release
 
 
 FROM registry.access.redhat.com/ubi8/dotnet-60:6.0-32.20230511125009
-EXPOSE 8081
-ENV ASPNETCORE_URLS=http://*:8081
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
 COPY --from=builder /opt/app-root/src/bin /opt/app-root/src/bin
 WORKDIR /opt/app-root/src/bin/Release/net6.0/publish
 CMD ["dotnet", "app.dll"]

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -18,7 +18,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - name: http
-              containerPort: 8081
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: devfile-dotnet-deploy
 spec:
   ports:
-    - name: http-8081
-      port: 8081
+    - name: http-8080
+      port: 8080
       protocol: TCP
-      targetPort: 8081
+      targetPort: 8080
   selector:
     app: devfile-dotnet-deploy
   type: LoadBalancer


### PR DESCRIPTION
- Updates the devfile sample port from 8081 to 8080
- Doesnt update the attribute alpha.dockerimage-port: 8081 because of backward compatibility in ODC earlier versions. We dont want to backport devfile/library update that far back.