### PR TITLE
Enable TLS

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -56,6 +56,7 @@ components:
         - name: http-8081
           targetPort: 8081
           path: /
+          secure: true
   - name: kubernetes-service
     attributes:
       deployment/replicas: 1


### PR DESCRIPTION
# Description

Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled.

This should enable TLS on OpenShift for this sample when web console has been patched: https://github.com/devfile/api/issues/1270#issuecomment-1866424653

fixes part of devfile/api#1270