### PR TITLE
Fix slug name for dockerfile renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     {
       "matchManagers": ["dockerfile"],
       "groupName": "dockerfile dependencies",
-      "groupSlug": "nuget-deps",
+      "groupSlug": "dockerfile-deps",
       "commitMessageTopic": "Dockerfile {{depName}}"
       
     },


### PR DESCRIPTION
## Fix slug name for dockerfile renovate group

A typo with dockerfile renovate group slug that uses the same as NuGet group, introduced in #13, slug should be `dockerfile-deps`.